### PR TITLE
unify the format and add new Categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,13 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.16
   - [simonewebdesign/elm-simon](https://github.com/simonewebdesign/elm-simon) - Memory Game.
 - Elm 0.15
-  - [Cape Match](https://github.com/krisajenkins/cardmatch) - Memory Clone. A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
+  - [Cape Match](https://github.com/krisajenkins/cardmatch) - A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
 
 ### Asteroid
 - Elm 0.17
-  - [Elmsteroids](https://github.com/yupferris/elmsteroids) - Asteroid Game. A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
+  - [Elmsteroids](https://github.com/yupferris/elmsteroids) - A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
 - Elm 0.16
-  - [Destroid](https://github.com/BlackBrane/destroid) - Asteroid Game. A space shooter based on the classic Asteroids.
+  - [Destroid](https://github.com/BlackBrane/destroid) - A space shooter based on the classic Asteroids.
 
 ### Pac Man
 - Elm 0.18
@@ -124,7 +124,7 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [battermann/elm-samegame](https://github.com/battermann/elm-samegame) - SameGame clone. [[play]](https://samegame.surge.sh)
 - Elm 0.18
   - [w0rm/elm-cubik](https://github.com/w0rm/elm-cubik) - This is an implementation of the Rubik's cube puzzle in the Elm language using WebGL. [[doc]](https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746) [[play]](https://unsoundscapes.itch.io/cubik)
-  - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) [[play]] - Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
+  - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) - Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
   - [Sokoban Player](https://github.com/krzysu/elm-sokoban-player) - Sokoban Player provides best experience to play any sokoban level you want! [[play]](https://sokoban-player.netlify.com)
   - [w0rm/elm-nim](https://github.com/w0rm/elm-nim) - A live-coded implementation of the [Nim](https://en.wikipedia.org/wiki/Nim) game in Elm as done at Berlin Frontend Meetup. [[doc]](https://unsoundscapes.com/slides/2016-06-07-introduction-to-elm/)
 - Elm 0.12
@@ -132,8 +132,8 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ## Racing Game
 - Elm 0.18
-  - [Tacks](https://github.com/etaque/tacks) - Racing Game. Real-time multiplayer sailing game [[play]](http://www.playtacks.com)
-  - [Retrorace](https://github.com/nwjlyons/retrorace) - Racing Game. Retrorace is a multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
+  - [Tacks](https://github.com/etaque/tacks) - Real-time multiplayer sailing game [[play]](http://www.playtacks.com)
+  - [Retrorace](https://github.com/nwjlyons/retrorace) - Retrorace is a multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
 
 ## Tools
 - Elm 0.18

--- a/README.md
+++ b/README.md
@@ -1,115 +1,133 @@
 # All Elm Games (hopefully)
 
-## Snake
+There is also separate repository for gamedev: [Elm Game Development](https://github.com/rofrol/awesome-elm-gamedev)
 
-- https://github.com/liubko/elm-snake
-  - http://www.slideshare.net/theburningmonk/my-adventure-with-elm
-- https://github.com/rkrupinski/elm-snake
-- Dead link http://elm-by-example.org/chapter14snakerevisited.html
-- http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
-- https://github.com/nwjlyons/snake
-- https://github.com/ktonon/word-snake
-- http://freiguy1.gitlab.io/elm-snake/
-- https://github.com/tibastral/elm-snake
-- https://github.com/MartinSnyder/elm-snake
+## Snake
+- Elm 0.19
+  - https://github.com/MartinSnyder/elm-snake
+- Elm 0.18
+  - https://github.com/rkrupinski/elm-snake
+  - https://github.com/nwjlyons/snake
+  - https://github.com/ktonon/word-snake
+  - http://freiguy1.gitlab.io/elm-snake
+  - https://github.com/tibastral/elm-snake
+- Elm 0.15
+  - https://github.com/liubko/elm-snake
+    - http://www.slideshare.net/theburningmonk/my-adventure-with-elm
+- Dead Links
+  - http://elm-by-example.org/chapter14snakerevisited.html
+  - http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
 
 ## Tetris
-
-- https://github.com/jcollard/elmtris
-- https://github.com/hoelzro/elm-tetris
-- https://github.com/marcospri/elmtris
+- Elm 0.18
+  - https://github.com/hoelzro/elm-tetris
+  - https://github.com/marcospri/elmtris
+- Elm 0.12
+  - https://github.com/jcollard/elmtris
 
 ## Roguelike
+- https://github.com/sindikat/roguelike
+- Elm 0.19
+  - Dig Dig Boom https://orasund.itch.io/dig-dig-boom
+- Elm 0.13
+  - https://github.com/deadfoxygrandpa/Roguelike
 
-- Dig Dig Boom https://orasund.itch.io/dig-dig-boom
-- Roguelike https://github.com/sindikat/roguelike
-- https://github.com/deadfoxygrandpa/Roguelike
-
-## Chess
-- https://github.com/grzegorzbalcerek/chess-elm
-- https://github.com/girishso/indian-chess
+## Chess-like
+- Elm 0.18
+  - https://github.com/girishso/indian-chess
+- Elm 0.13
+  - https://github.com/grzegorzbalcerek/chess-elm
 
 ## Real-Time Strategy
-
 - https://play.drtsgame.com
-- https://github.com/xarvh/herzog-drei/
+- Elm 0.19
+  - https://github.com/xarvh/herzog-drei
 
-## breakout
+## Breakout
+- Elm 0.18
+  - https://github.com/Dobiasd/Breakout
+  - https://github.com/hoelzro/elm-breakout
+- Elm 0.01
+  - https://github.com/kbaba1001/elm-breakout
 
-- http://daiw.de/games/breakout/
-- https://github.com/Dobiasd/Breakout
-- https://github.com/kbaba1001/elm-breakout
-- https://github.com/hoelzro/elm-breakout
-  
 ## Pong
-  
 - http://elm-lang.org/blog/making-pong
-- https://github.com/pristap/pong
-- https://github.com/davydog187/elm-pong
 - https://github.com/rmies/fp-ams-elm/blob/master/Pong.elm
-- https://github.com/r00k/elm-pong
-- https://github.com/bado22/elm-pong
+- Elm 0.18
+  - https://github.com/pristap/pong
+  - https://github.com/davydog187/elm-pong
 - Elm 0.17
   - https://gist.github.com/pdamoc/fd29925b8e20dd92e91c5b75e6c3711e
   - https://groups.google.com/forum/#!topic/elm-discuss/1aQLki2sUrY
+- Elm 0.16
+  - https://github.com/r00k/elm-pong
+- Elm 0.01
+  - Pong https://github.com/sonnym/elm-expressway_pong
+- Dead Links
+  - https://github.com/bado22/elm-pong
 
 ## Tower defense
+- Elm 0.18
+  - https://github.com/JoelQ/safe-tea
 
-- https://github.com/JoelQ/safe-tea
-
-## Rest
-
-There is also separate repository for gamedev: [Elm Game Development](https://github.com/rofrol/awesome-elm-gamedev)
-
-- https://github.com/danneu/melted-synapse
-- https://github.com/danneu/elm-tile-editor
-- https://github.com/danneu/elm-space-arena
-- https://github.com/danneu/elm-hex-grid
-- https://github.com/danneu/infinite-monkey-incremental
-- https://github.com/avh4/elm-mario
-
-
-- https://github.com/jvoigtlaender/labyrinth-elm
-- https://github.com/johnpmayer/celestia
-- https://github.com/avh4/wire-game
-- https://github.com/BlackBrane/destroid
-- https://github.com/slawrence/vessel
-
-- An intro to games in Elm http://elm-lang.org/blog/making-pong
-- https://github.com/etaque/tacks
-- https://github.com/mgold/Sequence-Maze
-- https://github.com/basti1302/elm-turing-machine-game
-- https://github.com/mikegehard/elm-minesweeper
-- https://github.com/sonnym/elm-expressway_pong
-- https://github.com/ohanhi/elmvaders
-- https://github.com/FireflyLogic/pewpew
-- https://github.com/Lopi/HackMan
-- https://github.com/bamboo/take-the-blue-pills
-- elm rocket lander
-  - https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html
-  - https://github.com/WeAreWizards/elm-rocket-lander
-  - https://blog.wearewizards.io/experience-report-rocket-lander-in-elm
-  - https://news.ycombinator.com/item?id=9068685
 - https://github.com/etaque/tacks
 - https://github.com/zalando/elm-street-404
 - https://github.com/w0rm/elm-flatris
 
-- Mario
-  - https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm
-  - https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario
-  - http://debug.elm-lang.org/edit/Mario.elm
-  - Elm 0.17
-    - https://gist.github.com/pdamoc/6f7aa2d3774e5af58ebeba369637c228
+## Mario
+- Elm 0.18
+  - https://github.com/avh4/elm-mario
+- Elm 0.17
+  - https://gist.github.com/pdamoc/6f7aa2d3774e5af58ebeba369637c228
     - https://groups.google.com/forum/#!topic/elm-discuss/1aQLki2sUrY
+- Elm 0.12
+  - https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm
+    - https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario
+    - Dead http://debug.elm-lang.org/edit/Mario.elm
 
-- elmsteroids
-  - http://yupferris.github.io/elmsteroids/
-  - https://github.com/yupferris/elmsteroids
-- https://github.com/krisajenkins/transcodegame
-- https://github.com/Zinggi/elm-2d-game
-- https://github.com/martimatix/sweet-sweet-friction/
-- https://github.com/cabaret/elm-supercrypt
-- https://github.com/krisajenkins/wireworld
+## Tools
+- Elm 0.18
+  - hex grid pathfinding package https://github.com/danneu/elm-hex-grid
+- Elm 0.17
+  - tile editor https://github.com/danneu/elm-tile-editor
+
+## Miscellaneous
+- educational game https://github.com/mgold/Sequence-Maze
+- hacking game https://github.com/Lopi/HackMan
+- Elm 0.18
+  - Real-time multiplayer sailing game https://github.com/etaque/tacks
+  - rocket lander https://github.com/WeAreWizards/elm-rocket-lander
+    - dead https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html
+    - dead https://blog.wearewizards.io/experience-report-rocket-lander-in-elm
+    - https://news.ycombinator.com/item?id=9068685
+  - sweet sweet friction https://github.com/martimatix/sweet-sweet-friction/
+- Elm 0.17
+  - fighting game https://github.com/danneu/melted-synapse
+  - space shooter https://github.com/danneu/elm-space-arena
+  - asteroids
+    - https://github.com/yupferris/elmsteroids
+      - http://yupferris.github.io/elmsteroids
+  - point&click adventure https://github.com/krisajenkins/transcodegame
+  - decryption game https://github.com/cabaret/elm-supercrypt
+  - cellular automata https://github.com/krisajenkins/wireworld
+- Elm 0.16
+  - incremental game https://github.com/danneu/infinite-monkey-incremental
+  - pac-man https://github.com/jvoigtlaender/labyrinth-elm
+  - space shooter https://github.com/BlackBrane/destroid
+  - minesweeper https://github.com/mikegehard/elm-minesweeper
+- Elm 0.15
+  - spaceship game https://github.com/johnpmayer/celestia
+  - network topology game https://github.com/avh4/wire-game
+  - turing machine game https://github.com/basti1302/elm-turing-machine-game
+  - space Invaders https://github.com/ohanhi/elmvaders
+- Elm 0.14
+  - driving game https://github.com/slawrence/vessel
+  - item collecting game https://github.com/bamboo/take-the-blue-pills
+- Elm 0.13
+  - space shooter game https://github.com/FireflyLogic/pewpew
+
+
+
 - https://github.com/krisajenkins/the-prize
 - https://github.com/krisajenkins/infinite-runner
 - https://github.com/krisajenkins/lunarlander/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 There is also separate repository for gamedev: [Elm Game Development](https://github.com/rofrol/awesome-elm-gamedev)
 
-## Snake
-- Dead http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
+## Clones of Common Games
+### Snake
 - Elm 0.19
-  - [MartinSnyder/elm-snake](https://github.com/MartinSnyder/elm-snake) - implementation of classic game "Snake". [[play]](http://martinsnyder.net/snake)
+  - [MartinSnyder/elm-snake](https://github.com/MartinSnyder/elm-snake) - Implementation of classic game "Snake". [[play]](http://martinsnyder.net/snake)
 - Elm 0.18
   - [rkrupinski/elm-snake](https://github.com/rkrupinski/elm-snake) - Snake game. [[play]](https://rkrupinski.github.io/elm-snake)
   - [nwjlyons/snake](https://github.com/nwjlyons/snake) - Classic game Snake. [[play]](http://snake.neillyons.io)
@@ -15,9 +15,10 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.15
   - [liubko/elm-snake](https://github.com/liubko/elm-snake) [[doc]](http://www.slideshare.net/theburningmonk/my-adventure-with-elm) - A Snake game for the web browser. [[play]](http://liubko.github.io/elm-snake)
 - Elm 0.14
-  - [Chapter 14 Snake Revisited](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter14SnakeRevisited.elm) - part of the elm-by-example book.
+  - [Chapter 14 Snake Revisited](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter14SnakeRevisited.elm) - Part of the elm-by-example book.
+- Dead http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
 
-## Tetris
+### Tetris
 - Elm 0.19
   - [w0rm/elm-flatris](https://github.com/w0rm/elm-flatris) - A [Flatris](https://github.com/skidding/flatris) clone. [[play]](https://unsoundscapes.itch.io/flatris)
 - Elm 0.18
@@ -26,35 +27,14 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.12
   - [jcollard/elmtris](https://github.com/jcollard/elmtris) - A Tetris game for the web browser.
 
-## Roguelike
-- [sindikat/roguelike](https://github.com/sindikat/roguelike) - Roguelike draft for testing Elm's Graphics.Collage performance.
-- Elm 0.19
-  - [Dig Dig Boom](https://github.com/Orasund/pixelengine/tree/master/docs/DigDigBoom) - Roguelike with breakable walls. [[play]](https://orasund.itch.io/dig-dig-boom)
-- Elm 0.13
-  - [deadfoxygrandpa/Roguelike](https://github.com/deadfoxygrandpa/Roguelike) - A roguelike.
-
-## Chess-like
-- Elm 0.18
-  - [girishso/indian-chess](https://github.com/girishso/indian-chess) - 18th Century chess like game developed. [[play]](http://indianchess.info)
-- Elm 0.13
-  - [grzegorzbalcerek/chess-elm](https://github.com/grzegorzbalcerek/chess-elm) - The game of Chess written in Elm.
-
-## Real-Time Strategy
-- DRTS Game [[play]](https://play.drtsgame.com)
-- Elm 0.19
-  - [Herzog Drei](https://github.com/xarvh/herzog-drei) - RTS game based on [Herzog Zwei](https://en.wikipedia.org/wiki/Herzog_Zwei). [[play]](https://xarvh.github.io/herzog-drei)
-
-## Breakout
+### Breakout
 - Elm 0.18
   - [Dobiasd/Breakout](https://github.com/Dobiasd/Breakout) - A clone of the classical game for your browser. [[play]](http://daiw.de/games/breakout)
   - [hoelzro/elm-breakout](https://github.com/hoelzro/elm-breakout) - An implementation of Breakout.
 - Elm 0.01
   - [kbaba1001/elm-breakout](https://github.com/kbaba1001/elm-breakout)
 
-## Pong
-- Making Pong Tutorial [[doc]](http://elm-lang.org/blog/making-pong) - Outdated (from 2012).
-- Dead https://github.com/bado22/elm-pong
-- [rmies/fp-ams-elm](https://github.com/rmies/fp-ams-elm/blob/master/Pong.elm) - Outdated (from 2015).
+### Pong
 - Elm 0.18
   - [pristap/pong](https://github.com/pristap/pong) - Pong written in Elm using [Elmo-8](https://github.com/micktwomey/elmo-8). [[play]](http://www.pristap.com/pong)
   - [davydog187/elm-pong](https://github.com/davydog187/elm-pong) - Pong based on the example from [the Elm-lang website](http://elm-lang.org/blog/making-pong), with some additional features.
@@ -64,11 +44,13 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [r00k/elm-pong](https://github.com/r00k/elm-pong)
 - Elm 0.01
   - [sonnym/elm-expressway_pong](https://github.com/sonnym/elm-expressway_pong) - Multiplayer pong using Node.js and Elm.
+- Making Pong Tutorial [[doc]](http://elm-lang.org/blog/making-pong) - Outdated (from 2012).
+- Dead https://github.com/bado22/elm-pong
+- [rmies/fp-ams-elm](https://github.com/rmies/fp-ams-elm/blob/master/Pong.elm) - Outdated (from 2015).
 
-
-## Mario
+### Mario
 - Elm 0.18
-  - [avh4/elm-mario](https://github.com/avh4/elm-mario) - The Elm Mario example from the Elm-lang website. [play](https://avh4.github.io/elm-mario)
+  - [avh4/elm-mario](https://github.com/avh4/elm-mario) - The Elm Mario example from the Elm-lang website. [[play]](https://avh4.github.io/elm-mario)
 - Elm 0.17
   - [pdamoc/Mario.elm](https://gist.github.com/pdamoc/6f7aa2d3774e5af58ebeba369637c228) - Mario Example.
 - Elm 0.13
@@ -76,57 +58,114 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.12
   - [Evan's Mario Example](https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm) [[resources]](https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario) - Original example for mario in elm.
 
+### Tic Tac Toe
+- Elm 0.18
+  - [ZeusTheTrueGod/elm-tictactoe](https://github.com/ZeusTheTrueGod/elm-tictactoe) - Tic Tac Toe Clone.
+- [Chapter 12 Tic Tac Toe](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter12TicTacToe.elm)  - Part of the elm-by-example book. Outdated (from 2015).
+
+### Space Invaders
+- Elm 0.18
+  - [Genetic Space Invaders game](https://github.com/j1nma/genetic-space-invaders) - A functional game written in Elm about classic space invaders game evolved with a genetic algorithm. [[play]](https://j1nma.github.io/genetic-space-invaders/)
+- Elm 0.16
+  - [ohanhi/elmvaders](https://github.com/ohanhi/elmvaders) - Simple Space Invaders inspired game. [[play]](https://ohanhi.github.io/elmvaders)
+- Elm 0.13
+  - [Pew Pew](https://github.com/FireflyLogic/pewpew) - A space shooter game.
+
+### Memory
+- Elm 0.18
+  - [Pairs.one](https://github.com/mxgrn/pairs.one) - A neat multiplayer online memory/concentration game. [[play]](https://pairs.one)
+- Elm 0.16
+  - [simonewebdesign/elm-simon](https://github.com/simonewebdesign/elm-simon) - Memory Game.
+- Elm 0.15
+  - [Cape Match](https://github.com/krisajenkins/cardmatch) - Memory Clone. A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
+
+### Asteroid
+- Elm 0.17
+  - [Elmsteroids](https://github.com/yupferris/elmsteroids) - Asteroid Game. A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
+- Elm 0.16
+  - [Destroid](https://github.com/BlackBrane/destroid) - Asteroid Game. A space shooter based on the classic Asteroids.
+
+### Pac Man
+- Elm 0.18
+  - [abadi199/elman](https://github.com/abadi199/elman) - Pac Man Clone. [[play]](https://abadi199.github.io/elman)
+  - [duckmole/elm-pacman](https://github.com/duckmole/elm-pacman) - Coding-Dojo : Pacman in ELM.
+
+### Minesweeper
+- Elm 0.18
+  - [roSievers/elm-sweeper](https://github.com/roSievers/elm-sweeper) - Elm Sweeper aims to reimplement the puzzle mechanics of Hexcells as a web application. [[play]](https://rosievers.github.io/elm-sweeper)
+  - [brandly/elm-minesweeper](https://github.com/brandly/elm-minesweeper) - Classic Minesweeper. [[play]](https://brandly.github.io/elm-minesweeper/)
+- Elm 0.16
+  - [mikegehard/elm-minesweeper](https://github.com/mikegehard/elm-minesweeper) - A minesweeper game. [[play]](http://mikegehard.github.io/elm-minesweeper)
+
+## Roguelike
+- Elm 0.19
+  - [Dig Dig Boom](https://github.com/Orasund/pixelengine/tree/master/docs/DigDigBoom) - Roguelike with breakable walls. [[play]](https://orasund.itch.io/dig-dig-boom)
+- Elm 0.13
+  - [deadfoxygrandpa/Roguelike](https://github.com/deadfoxygrandpa/Roguelike) - A roguelike.
+- [sindikat/roguelike](https://github.com/sindikat/roguelike) - Roguelike draft for testing Elm's Graphics.Collage performance.
+
+## Classic Card & Board Game
+- Elm 0.18
+  - [girishso/indian-chess](https://github.com/girishso/indian-chess) - 18th Century chess like game developed. [[play]](http://indianchess.info)
+  - [jinjor/elm-reversi](https://github.com/jinjor/elm-reversi) - Reversi Clone. [[play]](https://jinjor.github.io/elm-reversi)
+  - [cbenz/elm-bridge-game](https://github.com/cbenz/elm-bridge-game) - Card Game. Experimentations in Elm around Bridge card game using French standard. [[play]](https://cbenz.github.io/elm-bridge-game)
+- Elm 0.15
+  - [Checkerboard Grid Tutorial](https://github.com/TheSeamau5/elm-checkerboardgrid-tutorial) - Tutorial on Container Components in Elm.
+- Elm 0.13
+  - [grzegorzbalcerek/chess-elm](https://github.com/grzegorzbalcerek/chess-elm) - The game of Chess written in Elm.
+
+## Real-Time Strategy
+- Elm 0.19
+  - [Herzog Drei](https://github.com/xarvh/herzog-drei) - RTS game based on [Herzog Zwei](https://en.wikipedia.org/wiki/Herzog_Zwei). [[play]](https://xarvh.github.io/herzog-drei)
+- DRTS Game [[play]](https://play.drtsgame.com)
+
+## Puzzle Games
+- Elm 0.19
+  - [battermann/elm-samegame](https://github.com/battermann/elm-samegame) - SameGame clone. [[play]](https://samegame.surge.sh)
+- Elm 0.18
+  - [w0rm/elm-cubik](https://github.com/w0rm/elm-cubik) - This is an implementation of the Rubik's cube puzzle in the Elm language using WebGL. [[doc]](https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746) [[play]](https://unsoundscapes.itch.io/cubik)
+  - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) [[play]] - Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
+  - [Sokoban Player](https://github.com/krzysu/elm-sokoban-player) - Sokoban Player provides best experience to play any sokoban level you want! [[play]](https://sokoban-player.netlify.com)
+  - [w0rm/elm-nim](https://github.com/w0rm/elm-nim) - A live-coded implementation of the [Nim](https://en.wikipedia.org/wiki/Nim) game in Elm as done at Berlin Frontend Meetup. [[doc]](https://unsoundscapes.com/slides/2016-06-07-introduction-to-elm/)
+- Elm 0.12
+  - [maxsnew/Scramble](https://github.com/maxsnew/Scramble) - Word Scramble Game. [[play]](http://maxsnew.github.io/Scramble)
+
+## Racing Game
+- Elm 0.18
+  - [Tacks](https://github.com/etaque/tacks) - Racing Game. Real-time multiplayer sailing game [[play]](http://www.playtacks.com)
+  - [Retrorace](https://github.com/nwjlyons/retrorace) - Racing Game. Retrorace is a multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
+
 ## Tools
 - Elm 0.18
-  - [hex grid pathfinding package](https://github.com/danneu/elm-hex-grid) - A hex-grid package for elm. [[try]](https://www.danneu.com/elm-hex-grid)
+  - [hex grid pathfinding package](https://github.com/danneu/elm-hex-grid) - A hex-grid package for elm.
 - Elm 0.17
   - [tile editor](https://github.com/danneu/elm-tile-editor) - A tilemap editor built with elm.
 
 ## Miscellaneous
-- [mgold/Sequence-Maze](https://github.com/mgold/Sequence-Maze) - Educational Game. A game for small children. Outdated (from 2014).
-- [Lopi/HackMan](https://github.com/Lopi/HackMan) - Hacking Game. A game to teach users about security and penetration testing. Outdated (from 2015).
-- [Chapter 12 Tic Tac Toe](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter12TicTacToe.elm)  - Tic Tac Toe Clone. Part of the elm-by-example book. Outdated (from 2015).
-- [sonnym/petrov](https://github.com/sonnym/petrov) - Red Button Game. Don't press the button. [[play]](http://ludumdare.com/compo/ludum-dare-28/?action=preview&uid=28886)
-- [monsieurcactus/LearnElm](https://github.com/monsieurcactus/LearnElm) A collection of one-file games.
 - Elm 0.19
   - [Mogee](https://github.com/w0rm/elm-mogee) - Platformer game. A WebGL platformer that fits into 64x64px screen. [[doc]](https://www.youtube.com/watch?v=NRXTMaXO15I) [[play]](https://unsoundscapes.itch.io/mogee)
   - [sonnym/scorched](https://github.com/sonnym/scorched) - Turn-based artillery game. A clone of Scorched Earth.
   - [JordyMoos/elm-pixel-boulder-game](https://github.com/JordyMoos/elm-pixel-boulder-game) - Boulder Dash Clone. A bit "out-of-hand" experiment to write a game in a pure functional language. [[play]](https://jordymoos.github.io/elm-pixel-boulder-game)
-  - [battermann/elm-samegame](https://github.com/battermann/elm-samegame) - Puzzle Game. SameGame clone. [[play]](https://samegame.surge.sh)
 - Elm 0.18
-  - [Tacks](https://github.com/etaque/tacks) - Racing Game. Real-time multiplayer sailing game [[play]](http://www.playtacks.com)
   - [WeAreWizards/elm-rocket-lander](https://github.com/WeAreWizards/elm-rocket-lander) - Rocket lander Game. A simple rocket lander game written in Elm
     - dead https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html
     - dead https://blog.wearewizards.io/experience-report-rocket-lander-in-elm
     - https://news.ycombinator.com/item?id=9068685
   - [Sweet Sweet Friction](https://github.com/martimatix/sweet-sweet-friction) - Arcade Game. A Gimme Friction Baby clone. [[play]](https://martimatix.github.io/sweet-sweet-friction)
   - [Elm Street 404](https://github.com/zalando/elm-street-404) - Pathing Game. Deliver all the fashion to all the customers. [[play]](https://opensource.zalando.com/elm-street-404)
-  - [Safe Tea](https://github.com/JoelQ/safe-tea) - Tower Defense.Pirate-themed tower defense game for the Feb 2018 [Elm Game Jam](http://elmgames.club). [[play]](https://joelq.itch.io/safe-tea)
+  - [Safe Tea](https://github.com/JoelQ/safe-tea) - Tower Defense. Pirate-themed tower defense game for the Feb 2018 [Elm Game Jam](http://elmgames.club). [[play]](https://joelq.itch.io/safe-tea)
   - [eniac314/elmGol](https://github.com/eniac314/elmGol) - Celluar Automata. Conway's Game of Life.
   - [fbonetti/elm-game-of-life](https://github.com/fbonetti/elm-game-of-life) - Celluar Automata. Conway's Game of Life.
-  - [w0rm/elm-nim](https://github.com/w0rm/elm-nim) - Nim Game. A live-coded implementation of the [Nim](https://en.wikipedia.org/wiki/Nim) game in Elm as done at Berlin Frontend Meetup. [[doc]](https://unsoundscapes.com/slides/2016-06-07-introduction-to-elm/)
-  - [Pairs.one](https://github.com/mxgrn/pairs.one) - Memory Clone. a neat multiplayer online memory/concentration game. [[play]](https://pairs.one)
-  - [abadi199/elman](https://github.com/abadi199/elman) - Pac Man Clone. [[play]](https://abadi199.github.io/elman)
-  - [duckmole/elm-pacman](https://github.com/duckmole/elm-pacman) - Pac Man Clone. Coding-Dojo : Pacman in ELM.
   - [jamonholmgren/rocket-elm](https://github.com/jamonholmgren/rocket-elm) - Spaceship Game. A small game where you pilot a rocket ship around.
-  - [jinjor/elm-reversi](https://github.com/jinjor/elm-reversi) - Reversi Clone. [[play]](https://jinjor.github.io/elm-reversi)
-  - [ZeusTheTrueGod/elm-tictactoe](https://github.com/ZeusTheTrueGod/elm-tictactoe) - Tic Tac Toe Clone.
-  - [Retrorace](https://github.com/nwjlyons/retrorace) - Racing Game. Retrorace is a multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
-  - [roSievers/elm-sweeper](https://github.com/roSievers/elm-sweeper) - Minesweeper clone. Elm Sweeper aims to reimplement the puzzle mechanics of Hexcells as a web application. [[play]](https://rosievers.github.io/elm-sweeper)
   - [bahalperin/planeshift](https://github.com/bahalperin/planeshift)
   - [rommsen/elm-dots-and-boxes](https://github.com/rommsen/elm-dots-and-boxes) Multiplayer Dots and Boxes. [[play]](https://elm-dots-and-boxes.firebaseapp.com)
-  - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) [[play]] - Puzzle game. Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
-  - [Genetic Space Invaders game](https://github.com/j1nma/genetic-space-invaders) - A functional game written in Elm about classic space invaders game evolved with a genetic algorithm. [[play]](https://j1nma.github.io/genetic-space-invaders/)
-  - [Sokoban Player](https://github.com/krzysu/elm-sokoban-player) - Puzzle Game. Sokoban Player provides best experience to play any sokoban level you want! [[play]](https://sokoban-player.netlify.com)
-  - [stefankreitmayer/elm-joust](https://github.com/stefankreitmayer/elm-joust) fighting game. A minimalistic action game. [[play]](http://www.kreitmayer.com//elm-joust)
+  - [stefankreitmayer/elm-joust](https://github.com/stefankreitmayer/elm-joust) Fighting game. A minimalistic action game. [[play]](http://www.kreitmayer.com//elm-joust)
   - [tibastral/elm-koala](https://github.com/tibastral/elm-koala)
   - [brandly/elm-slime-volleyball](https://github.com/brandly/elm-slime-volleyball) - Gravity based game. try to beat the blue slime at volleyball. [[play]](https://brandly.github.io/elm-slime-volleyball/)
-  - [brandly/elm-minesweeper](https://github.com/brandly/elm-minesweeper) - Minesweeper clone. Classic Minesweeper. [[play]](https://brandly.github.io/elm-minesweeper/)
-  - [cbenz/elm-bridge-game](https://github.com/cbenz/elm-bridge-game) - Card Game. Experimentations in Elm around Bridge card game using French standard. [[play]](https://cbenz.github.io/elm-bridge-game)
+  - [Down the River](https://github.com/JoelQ/down-the-river) - Frogger Clone. Roman mythology themed game with procedural generation. [[play]](https://joelq.itch.io/down-the-river)
 - Elm 0.17
   - [Melted Synapse](https://github.com/danneu/melted-synapse) - Fighting Game. A turn-based game written in Elm that explores Frozen Synapse's game mechanics [[play]](https://www.danneu.com/melted-synapse)
   - [danneu/elm-space-arena](https://github.com/danneu/elm-space-arena) - Space Shooter. A sloppy 2D spaceship shooter. [[play]](https://www.danneu.com/elm-space-arena)
-  - [Elmsteroids](https://github.com/yupferris/elmsteroids) - Asteroid Game. A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
   - https://github.com/krisajenkins/transcodegame - Point&Click Adventure. A point & click adventure written. [[play]](http://krisajenkins.github.io/transcodegame)
       - [older version (Elm 0.16)](https://github.com/krisajenkins/the-prize)
   - [cabaret/elm-supercrypt](https://github.com/cabaret/elm-supercrypt) - Decryption Game. Elm implementation of [SuperCrypt](http://www.kevindecock.be/apps/supercrypt).
@@ -134,26 +173,18 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.16
   - [Infinite Monkey Incremental](https://github.com/danneu/infinite-monkey-incremental) - Incremental Game. An incremental game inspired by the Infinite Monkey Theorem [[play]](https://www.danneu.com/infinite-monkey-incremental)
   - [jvoigtlaender/labyrinth-elm](https://github.com/jvoigtlaender/labyrinth-elm) - Arcade Game. A Pac-Man clone.[[play]](http://www.janis-voigtlaender.eu/elm-labyrinth)
-  - [Destroid](https://github.com/BlackBrane/destroid) - Asteroid Game. A space shooter based on the classic Asteroids.
-  - [mikegehard/elm-minesweeper](https://github.com/mikegehard/elm-minesweeper) - Minesweeper Game. A minesweeper game. [[play]](http://mikegehard.github.io/elm-minesweeper)
   - [fbonetti/clicker-game](https://github.com/fbonetti/clicker-game) - Incremental Game. Cookie clicker clone.
-  - [simonewebdesign/elm-simon](https://github.com/simonewebdesign/elm-simon) - Memory Game.
-  - [Elm Plane](https://github.com/odedw/elm-plane) - Side scroller Game. A flappy bird clone written in elm. [[play]](http://www.odedwelgreen.com/elm-plane)
+  - [Elm Plane](https://github.com/odedw/elm-plane) - Autoscroller. A flappy bird clone written in elm. [[play]](http://www.odedwelgreen.com/elm-plane)
 - Elm 0.15
   - [celestia](https://github.com/johnpmayer/celestia) - Spaceship Game. Celestia is a two-dimensional cartoon space game. [[play]](http://johnpmayer.github.io/celestia)
-  - [avh4/wire-game](https://github.com/avh4/wire-game) - network topology game.
-  - [basti1302/elm-turing-machine-game](https://github.com/basti1302/elm-turing-machine-game) - turing machine game.
-  - [ohanhi/elmvaders](https://github.com/ohanhi/elmvaders) - Space Invaders Clone. Simple Space Invaders inspired game. [[play]](https://ohanhi.github.io/elmvaders)
-  - [krisajenkins/infinite-runner](https://github.com/krisajenkins/infinite-runner) - Infinite Runner Clone. A 90 Minute Infinite-Runner hack. [[play]](http://krisajenkins.github.io/infinite-runner)
+  - [avh4/wire-game](https://github.com/avh4/wire-game) - Network topology game.
+  - [basti1302/elm-turing-machine-game](https://github.com/basti1302/elm-turing-machine-game) - Turing machine game.
+  - [krisajenkins/infinite-runner](https://github.com/krisajenkins/infinite-runner) - Autoscroller. A 90 Minute Infinite-Runner hack. [[play]](http://krisajenkins.github.io/infinite-runner)
   - [krisajenkins/lunarlander](https://github.com/krisajenkins/lunarlander) - Rocket Lander Game. A Lunar Lander clone. [[play]](http://krisajenkins.github.io/lunarlander)
-  - [Cape Match](https://github.com/krisajenkins/cardmatch) - Memory Clone. A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
-  - [Checkerboard Grid Tutorial](https://github.com/TheSeamau5/elm-checkerboardgrid-tutorial) - Tutorial on Container Components in Elm.
 - Elm 0.14
-  - [Vessel](https://github.com/slawrence/vessel) - Driving Game. A "tunnel" game. [[play]](http://slawrence.github.io/vessel)
+  - [Vessel](https://github.com/slawrence/vessel) - Autoscroller. A "tunnel" game. [[play]](http://slawrence.github.io/vessel)
   - [bamboo/take-the-blue-pills](https://github.com/bamboo/take-the-blue-pills) - Item Collecting Game. Take the blue pills Elm tutorial.
-- Elm 0.13
-  - [Pew Pew](https://github.com/FireflyLogic/pewpew) - Space Invaders Clone. A space shooter game.
-- Elm 0.12
-  - [maxsnew/Scramble](https://github.com/maxsnew/Scramble) - Word Scramble Game. [[play]](http://maxsnew.github.io/Scramble)
-- [w0rm/elm-cubik](https://github.com/w0rm/elm-cubik) - Puzzle Game. This is an implementation of the Rubik's cube puzzle in the Elm language using WebGL. [[doc]](https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746) [[play]](https://unsoundscapes.itch.io/cubik)
-- [Down the River](https://github.com/JoelQ/down-the-river) - Frogger Clone. Roman mythology themed game with procedural generation. [[play]](https://joelq.itch.io/down-the-river)
+- [mgold/Sequence-Maze](https://github.com/mgold/Sequence-Maze) - Educational Game. A game for small children. Outdated (from 2014).
+- [Lopi/HackMan](https://github.com/Lopi/HackMan) - Hacking Game. A game to teach users about security and penetration testing. Outdated (from 2015).
+- [sonnym/petrov](https://github.com/sonnym/petrov) - Red Button Game. Don't press the button. [[play]](http://ludumdare.com/compo/ludum-dare-28/?action=preview&uid=28886)
+- [monsieurcactus/LearnElm](https://github.com/monsieurcactus/LearnElm) A collection of one-file games.

--- a/README.md
+++ b/README.md
@@ -3,171 +3,157 @@
 There is also separate repository for gamedev: [Elm Game Development](https://github.com/rofrol/awesome-elm-gamedev)
 
 ## Snake
+- Dead http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
 - Elm 0.19
-  - https://github.com/MartinSnyder/elm-snake
+  - [MartinSnyder/elm-snake](https://github.com/MartinSnyder/elm-snake) - implementation of classic game "Snake". [[play]](http://martinsnyder.net/snake)
 - Elm 0.18
-  - https://github.com/rkrupinski/elm-snake
-  - https://github.com/nwjlyons/snake
-  - https://github.com/ktonon/word-snake
-  - http://freiguy1.gitlab.io/elm-snake
-  - https://github.com/tibastral/elm-snake
+  - [rkrupinski/elm-snake](https://github.com/rkrupinski/elm-snake) - Snake game. [[play]](https://rkrupinski.github.io/elm-snake)
+  - [nwjlyons/snake](https://github.com/nwjlyons/snake) - Classic game Snake. [[play]](http://snake.neillyons.io)
+  - [ktonon/word-snake](https://github.com/ktonon/word-snake) - Asynchronous word search game. [[play]](http://wordsnake.betweenconcepts.com)
+  - [freiguy1/elm-snake](https://gitlab.com/freiguy1/elm-snake) - Snake game. [[play]](http://freiguy1.gitlab.io/elm-snake)
+  - [tibastral/elm-snake](https://github.com/tibastral/elm-snake) - Snake in WebGL and Html. [[play]](https://tibastral.github.io/elm-snake)
 - Elm 0.15
-  - https://github.com/liubko/elm-snake
-    - http://www.slideshare.net/theburningmonk/my-adventure-with-elm
-- Dead Links
-  - http://elm-by-example.org/chapter14snakerevisited.html
-  - http://www.elmfiddle.io/view/ciohidiwb0000ittvijce7hy5
+  - [liubko/elm-snake](https://github.com/liubko/elm-snake) [[doc]](http://www.slideshare.net/theburningmonk/my-adventure-with-elm) - A Snake game for the web browser. [[play]](http://liubko.github.io/elm-snake)
+- Elm 0.14
+  - [Chapter 14 Snake Revisited](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter14SnakeRevisited.elm) - part of the elm-by-example book.
 
 ## Tetris
+- Elm 0.19
+  - [w0rm/elm-flatris](https://github.com/w0rm/elm-flatris) - A [Flatris](https://github.com/skidding/flatris) clone. [[play]](https://unsoundscapes.itch.io/flatris)
 - Elm 0.18
-  - https://github.com/hoelzro/elm-tetris
-  - https://github.com/marcospri/elmtris
+  - [hoelzro/elm-tetris](https://github.com/hoelzro/elm-tetris) - A quick 'n' dirty implementation of Tetris.
+  - [marcospri/elmtris](https://github.com/marcospri/elmtris) - Basic implementation of tetris. [[play]](https://marcospri.github.io/elmtris)
 - Elm 0.12
-  - https://github.com/jcollard/elmtris
+  - [jcollard/elmtris](https://github.com/jcollard/elmtris) - A Tetris game for the web browser.
 
 ## Roguelike
-- https://github.com/sindikat/roguelike
+- [sindikat/roguelike](https://github.com/sindikat/roguelike) - Roguelike draft for testing Elm's Graphics.Collage performance.
 - Elm 0.19
-  - Dig Dig Boom https://orasund.itch.io/dig-dig-boom
+  - [Dig Dig Boom](https://github.com/Orasund/pixelengine/tree/master/docs/DigDigBoom) - Roguelike with breakable walls. [[play]](https://orasund.itch.io/dig-dig-boom)
 - Elm 0.13
-  - https://github.com/deadfoxygrandpa/Roguelike
+  - [deadfoxygrandpa/Roguelike](https://github.com/deadfoxygrandpa/Roguelike) - A roguelike.
 
 ## Chess-like
 - Elm 0.18
-  - https://github.com/girishso/indian-chess
+  - [girishso/indian-chess](https://github.com/girishso/indian-chess) - 18th Century chess like game developed. [[play]](http://indianchess.info)
 - Elm 0.13
-  - https://github.com/grzegorzbalcerek/chess-elm
+  - [grzegorzbalcerek/chess-elm](https://github.com/grzegorzbalcerek/chess-elm) - The game of Chess written in Elm.
 
 ## Real-Time Strategy
-- https://play.drtsgame.com
+- DRTS Game [[play]](https://play.drtsgame.com)
 - Elm 0.19
-  - https://github.com/xarvh/herzog-drei
+  - [Herzog Drei](https://github.com/xarvh/herzog-drei) - RTS game based on [Herzog Zwei](https://en.wikipedia.org/wiki/Herzog_Zwei). [[play]](https://xarvh.github.io/herzog-drei)
 
 ## Breakout
 - Elm 0.18
-  - https://github.com/Dobiasd/Breakout
-  - https://github.com/hoelzro/elm-breakout
+  - [Dobiasd/Breakout](https://github.com/Dobiasd/Breakout) - A clone of the classical game for your browser. [[play]](http://daiw.de/games/breakout)
+  - [hoelzro/elm-breakout](https://github.com/hoelzro/elm-breakout) - An implementation of Breakout.
 - Elm 0.01
-  - https://github.com/kbaba1001/elm-breakout
+  - [kbaba1001/elm-breakout](https://github.com/kbaba1001/elm-breakout)
 
 ## Pong
-- http://elm-lang.org/blog/making-pong
-- https://github.com/rmies/fp-ams-elm/blob/master/Pong.elm
+- Making Pong Tutorial [[doc]](http://elm-lang.org/blog/making-pong) - Outdated (from 2012).
+- Dead https://github.com/bado22/elm-pong
+- [rmies/fp-ams-elm](https://github.com/rmies/fp-ams-elm/blob/master/Pong.elm) - Outdated (from 2015).
 - Elm 0.18
-  - https://github.com/pristap/pong
-  - https://github.com/davydog187/elm-pong
+  - [pristap/pong](https://github.com/pristap/pong) - Pong written in Elm using [Elmo-8](https://github.com/micktwomey/elmo-8). [[play]](http://www.pristap.com/pong)
+  - [davydog187/elm-pong](https://github.com/davydog187/elm-pong) - Pong based on the example from [the Elm-lang website](http://elm-lang.org/blog/making-pong), with some additional features.
 - Elm 0.17
-  - https://gist.github.com/pdamoc/fd29925b8e20dd92e91c5b75e6c3711e
-  - https://groups.google.com/forum/#!topic/elm-discuss/1aQLki2sUrY
+  - [pdamoc/Pong.elm](https://gist.github.com/pdamoc/fd29925b8e20dd92e91c5b75e6c3711e) - Pong Example.
 - Elm 0.16
-  - https://github.com/r00k/elm-pong
+  - [r00k/elm-pong](https://github.com/r00k/elm-pong)
 - Elm 0.01
-  - Pong https://github.com/sonnym/elm-expressway_pong
-- Dead Links
-  - https://github.com/bado22/elm-pong
+  - [sonnym/elm-expressway_pong](https://github.com/sonnym/elm-expressway_pong) - Multiplayer pong using Node.js and Elm.
 
-## Tower defense
-- Elm 0.18
-  - https://github.com/JoelQ/safe-tea
-
-- https://github.com/etaque/tacks
-- https://github.com/zalando/elm-street-404
-- https://github.com/w0rm/elm-flatris
 
 ## Mario
 - Elm 0.18
-  - https://github.com/avh4/elm-mario
+  - [avh4/elm-mario](https://github.com/avh4/elm-mario) - The Elm Mario example from the Elm-lang website. [play](https://avh4.github.io/elm-mario)
 - Elm 0.17
-  - https://gist.github.com/pdamoc/6f7aa2d3774e5af58ebeba369637c228
-    - https://groups.google.com/forum/#!topic/elm-discuss/1aQLki2sUrY
+  - [pdamoc/Mario.elm](https://gist.github.com/pdamoc/6f7aa2d3774e5af58ebeba369637c228) - Mario Example.
+- Elm 0.13
+  - [dackerman/elm-mario-2](https://github.com/dackerman/elm-mario-2) - Modified mario game based on Evan's Mario.elm example.
 - Elm 0.12
-  - https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm
-    - https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario
-    - Dead http://debug.elm-lang.org/edit/Mario.elm
+  - [Evan's Mario Example](https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm) [[resources]](https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario) - Original example for mario in elm.
 
 ## Tools
 - Elm 0.18
-  - hex grid pathfinding package https://github.com/danneu/elm-hex-grid
+  - [hex grid pathfinding package](https://github.com/danneu/elm-hex-grid) - A hex-grid package for elm. [[try]](https://www.danneu.com/elm-hex-grid)
 - Elm 0.17
-  - tile editor https://github.com/danneu/elm-tile-editor
+  - [tile editor](https://github.com/danneu/elm-tile-editor) - A tilemap editor built with elm.
 
 ## Miscellaneous
-- educational game https://github.com/mgold/Sequence-Maze
-- hacking game https://github.com/Lopi/HackMan
+- [mgold/Sequence-Maze](https://github.com/mgold/Sequence-Maze) - Educational Game. A game for small children. Outdated (from 2014).
+- [Lopi/HackMan](https://github.com/Lopi/HackMan) - Hacking Game. A game to teach users about security and penetration testing. Outdated (from 2015).
+- [Chapter 12 Tic Tac Toe](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter12TicTacToe.elm)  - Tic Tac Toe Clone. Part of the elm-by-example book. Outdated (from 2015).
+- [sonnym/petrov](https://github.com/sonnym/petrov) - Red Button Game. Don't press the button. [[play]](http://ludumdare.com/compo/ludum-dare-28/?action=preview&uid=28886)
+- [monsieurcactus/LearnElm](https://github.com/monsieurcactus/LearnElm) A collection of one-file games.
+- Elm 0.19
+  - [Mogee](https://github.com/w0rm/elm-mogee) - Platformer game. A WebGL platformer that fits into 64x64px screen. [[doc]](https://www.youtube.com/watch?v=NRXTMaXO15I) [[play]](https://unsoundscapes.itch.io/mogee)
+  - [sonnym/scorched](https://github.com/sonnym/scorched) - Turn-based artillery game. A clone of Scorched Earth.
+  - [JordyMoos/elm-pixel-boulder-game](https://github.com/JordyMoos/elm-pixel-boulder-game) - Boulder Dash Clone. A bit "out-of-hand" experiment to write a game in a pure functional language. [[play]](https://jordymoos.github.io/elm-pixel-boulder-game)
+  - [battermann/elm-samegame](https://github.com/battermann/elm-samegame) - Puzzle Game. SameGame clone. [[play]](https://samegame.surge.sh)
 - Elm 0.18
-  - Real-time multiplayer sailing game https://github.com/etaque/tacks
-  - rocket lander https://github.com/WeAreWizards/elm-rocket-lander
+  - [Tacks](https://github.com/etaque/tacks) - Racing Game. Real-time multiplayer sailing game [[play]](http://www.playtacks.com)
+  - [WeAreWizards/elm-rocket-lander](https://github.com/WeAreWizards/elm-rocket-lander) - Rocket lander Game. A simple rocket lander game written in Elm
     - dead https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html
     - dead https://blog.wearewizards.io/experience-report-rocket-lander-in-elm
     - https://news.ycombinator.com/item?id=9068685
-  - sweet sweet friction https://github.com/martimatix/sweet-sweet-friction/
+  - [Sweet Sweet Friction](https://github.com/martimatix/sweet-sweet-friction) - Arcade Game. A Gimme Friction Baby clone. [[play]](https://martimatix.github.io/sweet-sweet-friction)
+  - [Elm Street 404](https://github.com/zalando/elm-street-404) - Pathing Game. Deliver all the fashion to all the customers. [[play]](https://opensource.zalando.com/elm-street-404)
+  - [Safe Tea](https://github.com/JoelQ/safe-tea) - Tower Defense.Pirate-themed tower defense game for the Feb 2018 [Elm Game Jam](http://elmgames.club). [[play]](https://joelq.itch.io/safe-tea)
+  - [eniac314/elmGol](https://github.com/eniac314/elmGol) - Celluar Automata. Conway's Game of Life.
+  - [fbonetti/elm-game-of-life](https://github.com/fbonetti/elm-game-of-life) - Celluar Automata. Conway's Game of Life.
+  - [w0rm/elm-nim](https://github.com/w0rm/elm-nim) - Nim Game. A live-coded implementation of the [Nim](https://en.wikipedia.org/wiki/Nim) game in Elm as done at Berlin Frontend Meetup. [[doc]](https://unsoundscapes.com/slides/2016-06-07-introduction-to-elm/)
+  - [Pairs.one](https://github.com/mxgrn/pairs.one) - Memory Clone. a neat multiplayer online memory/concentration game. [[play]](https://pairs.one)
+  - [abadi199/elman](https://github.com/abadi199/elman) - Pac Man Clone. [[play]](https://abadi199.github.io/elman)
+  - [duckmole/elm-pacman](https://github.com/duckmole/elm-pacman) - Pac Man Clone. Coding-Dojo : Pacman in ELM.
+  - [jamonholmgren/rocket-elm](https://github.com/jamonholmgren/rocket-elm) - Spaceship Game. A small game where you pilot a rocket ship around.
+  - [jinjor/elm-reversi](https://github.com/jinjor/elm-reversi) - Reversi Clone. [[play]](https://jinjor.github.io/elm-reversi)
+  - [ZeusTheTrueGod/elm-tictactoe](https://github.com/ZeusTheTrueGod/elm-tictactoe) - Tic Tac Toe Clone.
+  - [Retrorace](https://github.com/nwjlyons/retrorace) - Racing Game. Retrorace is a multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
+  - [roSievers/elm-sweeper](https://github.com/roSievers/elm-sweeper) - Minesweeper clone. Elm Sweeper aims to reimplement the puzzle mechanics of Hexcells as a web application. [[play]](https://rosievers.github.io/elm-sweeper)
+  - [bahalperin/planeshift](https://github.com/bahalperin/planeshift)
+  - [rommsen/elm-dots-and-boxes](https://github.com/rommsen/elm-dots-and-boxes) Multiplayer Dots and Boxes. [[play]](https://elm-dots-and-boxes.firebaseapp.com)
+  - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) [[play]] - Puzzle game. Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
+  - [Genetic Space Invaders game](https://github.com/j1nma/genetic-space-invaders) - A functional game written in Elm about classic space invaders game evolved with a genetic algorithm. [[play]](https://j1nma.github.io/genetic-space-invaders/)
+  - [Sokoban Player](https://github.com/krzysu/elm-sokoban-player) - Puzzle Game. Sokoban Player provides best experience to play any sokoban level you want! [[play]](https://sokoban-player.netlify.com)
+  - [stefankreitmayer/elm-joust](https://github.com/stefankreitmayer/elm-joust) fighting game. A minimalistic action game. [[play]](http://www.kreitmayer.com//elm-joust)
+  - [tibastral/elm-koala](https://github.com/tibastral/elm-koala)
+  - [brandly/elm-slime-volleyball](https://github.com/brandly/elm-slime-volleyball) - Gravity based game. try to beat the blue slime at volleyball. [[play]](https://brandly.github.io/elm-slime-volleyball/)
+  - [brandly/elm-minesweeper](https://github.com/brandly/elm-minesweeper) - Minesweeper clone. Classic Minesweeper. [[play]](https://brandly.github.io/elm-minesweeper/)
+  - [cbenz/elm-bridge-game](https://github.com/cbenz/elm-bridge-game) - Card Game. Experimentations in Elm around Bridge card game using French standard. [[play]](https://cbenz.github.io/elm-bridge-game)
 - Elm 0.17
-  - fighting game https://github.com/danneu/melted-synapse
-  - space shooter https://github.com/danneu/elm-space-arena
-  - asteroids
-    - https://github.com/yupferris/elmsteroids
-      - http://yupferris.github.io/elmsteroids
-  - point&click adventure https://github.com/krisajenkins/transcodegame
-  - decryption game https://github.com/cabaret/elm-supercrypt
-  - cellular automata https://github.com/krisajenkins/wireworld
+  - [Melted Synapse](https://github.com/danneu/melted-synapse) - Fighting Game. A turn-based game written in Elm that explores Frozen Synapse's game mechanics [[play]](https://www.danneu.com/melted-synapse)
+  - [danneu/elm-space-arena](https://github.com/danneu/elm-space-arena) - Space Shooter. A sloppy 2D spaceship shooter. [[play]](https://www.danneu.com/elm-space-arena)
+  - [Elmsteroids](https://github.com/yupferris/elmsteroids) - Asteroid Game. A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
+  - https://github.com/krisajenkins/transcodegame - Point&Click Adventure. A point & click adventure written. [[play]](http://krisajenkins.github.io/transcodegame)
+      - [older version (Elm 0.16)](https://github.com/krisajenkins/the-prize)
+  - [cabaret/elm-supercrypt](https://github.com/cabaret/elm-supercrypt) - Decryption Game. Elm implementation of [SuperCrypt](http://www.kevindecock.be/apps/supercrypt).
+  - [krisajenkins/wireworld](https://github.com/krisajenkins/wireworld) - Cellular automata. The WireWorld Cellular Automata.
 - Elm 0.16
-  - incremental game https://github.com/danneu/infinite-monkey-incremental
-  - pac-man https://github.com/jvoigtlaender/labyrinth-elm
-  - space shooter https://github.com/BlackBrane/destroid
-  - minesweeper https://github.com/mikegehard/elm-minesweeper
+  - [Infinite Monkey Incremental](https://github.com/danneu/infinite-monkey-incremental) - Incremental Game. An incremental game inspired by the Infinite Monkey Theorem [[play]](https://www.danneu.com/infinite-monkey-incremental)
+  - [jvoigtlaender/labyrinth-elm](https://github.com/jvoigtlaender/labyrinth-elm) - Arcade Game. A Pac-Man clone.[[play]](http://www.janis-voigtlaender.eu/elm-labyrinth)
+  - [Destroid](https://github.com/BlackBrane/destroid) - Asteroid Game. A space shooter based on the classic Asteroids.
+  - [mikegehard/elm-minesweeper](https://github.com/mikegehard/elm-minesweeper) - Minesweeper Game. A minesweeper game. [[play]](http://mikegehard.github.io/elm-minesweeper)
+  - [fbonetti/clicker-game](https://github.com/fbonetti/clicker-game) - Incremental Game. Cookie clicker clone.
+  - [simonewebdesign/elm-simon](https://github.com/simonewebdesign/elm-simon) - Memory Game.
+  - [Elm Plane](https://github.com/odedw/elm-plane) - Side scroller Game. A flappy bird clone written in elm. [[play]](http://www.odedwelgreen.com/elm-plane)
 - Elm 0.15
-  - spaceship game https://github.com/johnpmayer/celestia
-  - network topology game https://github.com/avh4/wire-game
-  - turing machine game https://github.com/basti1302/elm-turing-machine-game
-  - space Invaders https://github.com/ohanhi/elmvaders
+  - [celestia](https://github.com/johnpmayer/celestia) - Spaceship Game. Celestia is a two-dimensional cartoon space game. [[play]](http://johnpmayer.github.io/celestia)
+  - [avh4/wire-game](https://github.com/avh4/wire-game) - network topology game.
+  - [basti1302/elm-turing-machine-game](https://github.com/basti1302/elm-turing-machine-game) - turing machine game.
+  - [ohanhi/elmvaders](https://github.com/ohanhi/elmvaders) - Space Invaders Clone. Simple Space Invaders inspired game. [[play]](https://ohanhi.github.io/elmvaders)
+  - [krisajenkins/infinite-runner](https://github.com/krisajenkins/infinite-runner) - Infinite Runner Clone. A 90 Minute Infinite-Runner hack. [[play]](http://krisajenkins.github.io/infinite-runner)
+  - [krisajenkins/lunarlander](https://github.com/krisajenkins/lunarlander) - Rocket Lander Game. A Lunar Lander clone. [[play]](http://krisajenkins.github.io/lunarlander)
+  - [Cape Match](https://github.com/krisajenkins/cardmatch) - Memory Clone. A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
+  - [Checkerboard Grid Tutorial](https://github.com/TheSeamau5/elm-checkerboardgrid-tutorial) - Tutorial on Container Components in Elm.
 - Elm 0.14
-  - driving game https://github.com/slawrence/vessel
-  - item collecting game https://github.com/bamboo/take-the-blue-pills
+  - [Vessel](https://github.com/slawrence/vessel) - Driving Game. A "tunnel" game. [[play]](http://slawrence.github.io/vessel)
+  - [bamboo/take-the-blue-pills](https://github.com/bamboo/take-the-blue-pills) - Item Collecting Game. Take the blue pills Elm tutorial.
 - Elm 0.13
-  - space shooter game https://github.com/FireflyLogic/pewpew
-
-
-
-- https://github.com/krisajenkins/the-prize
-- https://github.com/krisajenkins/infinite-runner
-- https://github.com/krisajenkins/lunarlander/
-- https://github.com/krisajenkins/cardmatch
-- game of life https://github.com/eniac314/elmGol
-  - http://www.uminokirin.com/
-  - http://stackoverflow.com/questions/39955312/elm-game-of-life-program-becomes-unresponsive-is-there-a-way-to-fail-gracefull
-  - https://github.com/fbonetti/elm-game-of-life
-- https://github.com/maxsnew/Scramble
-- https://github.com/w0rm/elm-mogee
-  - http://unsoundscapes.com/slides/2016-05-10-mogee-or-how-i-fit-elm-in-a-64x64-grid/
-- https://github.com/w0rm/elm-nim
-- https://github.com/mxgrn/pairs.one
-- pacman WIP https://github.com/abadi199/elman
-- Coding-Dojo : Pacman in ELM https://github.com/duckmole/elm-pacman
-- https://github.com/TheSeamau5/elm-checkerboardgrid-tutorial
-- https://github.com/jamonholmgren/rocket-elm
-- https://github.com/jinjor/elm-reversi
-- https://github.com/ZeusTheTrueGod/elm-tictactoe
-- https://github.com/nwjlyons/retrorace
-- https://github.com/sonnym/scorched
-- https://github.com/sonnym/petrov
-- https://github.com/fbonetti/clicker-game
-- https://github.com/monsieurcactus/LearnElm/
-- memory game https://github.com/simonewebdesign/elm-simon
-- https://github.com/roSievers/elm-sweeper
-- https://github.com/bahalperin/planeshift
-- https://github.com/rommsen/elm-dots-and-boxes
-- https://github.com/jeanettehead/lady-boggle
-- A "tunnel" game https://github.com/slawrence/vessel
-- Genetic Space Invaders game https://github.com/j1nma/genetic-space-invaders
-- https://github.com/w0rm/elm-cubik
-  - https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746
-- https://github.com/krzysu/elm-sokoban-player
-- https://github.com/stefankreitmayer/elm-joust
-- https://github.com/tibastral/elm-koala
-- https://github.com/brandly/elm-slime-volleyball [[play]](https://brandly.github.io/elm-slime-volleyball/)
-- https://github.com/brandly/elm-minesweeper [[play]](https://brandly.github.io/elm-minesweeper/)
-- https://github.com/JoelQ/down-the-river
-- https://github.com/JordyMoos/elm-pixel-boulder-game
-- https://github.com/cbenz/elm-bridge-game
-- https://github.com/odedw/elm-plane
-- https://github.com/battermann/elm-samegame
+  - [Pew Pew](https://github.com/FireflyLogic/pewpew) - Space Invaders Clone. A space shooter game.
+- Elm 0.12
+  - [maxsnew/Scramble](https://github.com/maxsnew/Scramble) - Word Scramble Game. [[play]](http://maxsnew.github.io/Scramble)
+- [w0rm/elm-cubik](https://github.com/w0rm/elm-cubik) - Puzzle Game. This is an implementation of the Rubik's cube puzzle in the Elm language using WebGL. [[doc]](https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746) [[play]](https://unsoundscapes.itch.io/cubik)
+- [Down the River](https://github.com/JoelQ/down-the-river) - Frogger Clone. Roman mythology themed game with procedural generation. [[play]](https://joelq.itch.io/down-the-river)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.18
   - [Dobiasd/Breakout](https://github.com/Dobiasd/Breakout) - A clone of the classical game for your browser. [[play]](http://daiw.de/games/breakout)
   - [hoelzro/elm-breakout](https://github.com/hoelzro/elm-breakout) - An implementation of Breakout.
-- Elm 0.01
+- Elm 0.12
   - [kbaba1001/elm-breakout](https://github.com/kbaba1001/elm-breakout)
 
 ### Pong
@@ -42,7 +42,7 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [pdamoc/Pong.elm](https://gist.github.com/pdamoc/fd29925b8e20dd92e91c5b75e6c3711e) - Pong Example.
 - Elm 0.16
   - [r00k/elm-pong](https://github.com/r00k/elm-pong)
-- Elm 0.01
+- Elm 0.13
   - [sonnym/elm-expressway_pong](https://github.com/sonnym/elm-expressway_pong) - Multiplayer pong using Node.js and Elm.
 - Making Pong Tutorial [[doc]](http://elm-lang.org/blog/making-pong) - Outdated (from 2012).
 - Dead https://github.com/bado22/elm-pong


### PR DESCRIPTION
I unified the format: its now
    [Name of Project/Git Repos](Link to the source) -  Description [[doc]](link to any sort of documentation) [[play]](link to the playable game)

In doing so I noticed that there are quite a lot of clones of classic games as well as very similar games.
So I grouped them up:
* Any classical game that has two or more entries gets its own category (Tic Tac Toe, Space Invaders, Memory, Asteroid, Minesweeper
* Classic Card & Board Game, Puzzle Games and Racing Games got their own categories, because it felt like nice categories to have.

Additionally, I renamed "Rest" to "Miscellaneous". (I'm guessing it's a translation error coming from german? In that context Miscellaneous, meaning "Sonstiges" should be the right translation of the german word "Rest")
The Miscellaneous entries also got one-word categories in their description. (To better keep track of possibly new categories)

One small thing: There are 2 black sheep in the mix: The hex grid pathfinder and the tile editor.
I suggest to move the hex grid pathfinder to the awesome-elm-gamedev repos. (more on that i a separate PR)
I don't really know what to do with the tile editor though?