### PR TITLE
Add 120 additional Games.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,20 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.19
   - [MartinSnyder/elm-snake](https://github.com/MartinSnyder/elm-snake) - Implementation of classic game "Snake". [[play]](http://martinsnyder.net/snake)
 - Elm 0.18
+  - [remyferre/snake-elm](https://github.com/remyferre/snake-elm) - Snake game.
   - [rkrupinski/elm-snake](https://github.com/rkrupinski/elm-snake) - Snake game. [[play]](https://rkrupinski.github.io/elm-snake)
   - [nwjlyons/snake](https://github.com/nwjlyons/snake) - Classic game Snake. [[play]](http://snake.neillyons.io)
   - [ktonon/word-snake](https://github.com/ktonon/word-snake) - Asynchronous word search game. [[play]](http://wordsnake.betweenconcepts.com)
   - [freiguy1/elm-snake](https://gitlab.com/freiguy1/elm-snake) - Snake game. [[play]](http://freiguy1.gitlab.io/elm-snake)
   - [tibastral/elm-snake](https://github.com/tibastral/elm-snake) - Snake in WebGL and Html. [[play]](https://tibastral.github.io/elm-snake)
+- Elm 0.17
+  - [remyyounes/elm-snake](https://github.com/remyyounes/elm-snake) - Snake game. [[play]](http://remyyounes.github.io)
+  - [bobobobo/elm-game-lab](https://github.com/bobobobo/elm-game-lab) - Snake game. [[play]](https://bobobobo.github.io/elm-game-lab)
+  - [remyyounes/elm-snake](https://github.com/remyyounes/elm-snake) - Snake game. [[play]](http://remyyounes.github.io)
+- Elm 0.16
+  - [tatut/elmato](https://github.com/tatut/elmato) - Snake Game. [[play]](http://webjure.org/elmato)
+  - [rikukissa/elm-snake](https://github.com/rikukissa/elm-snake) - Snake game. [[play]](https://rikukissa.github.io/elm-snake)
+  - [franklsf95/smart-snake](https://github.com/franklsf95/smart-snake) - Play the snake game or watch AI control the perfect snake.
 - Elm 0.15
   - [liubko/elm-snake](https://github.com/liubko/elm-snake) [[doc]](http://www.slideshare.net/theburningmonk/my-adventure-with-elm) - A Snake game for the web browser. [[play]](http://liubko.github.io/elm-snake)
 - Elm 0.14
@@ -20,8 +29,11 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ### Tetris
 - Elm 0.19
+  - [brandly/elm-dr-mario](https://github.com/brandly/elm-dr-mario) - A Dr. Mario Clone. [[play]](https://brandly.github.io/elm-dr-mario)
   - [w0rm/elm-flatris](https://github.com/w0rm/elm-flatris) - A [Flatris](https://github.com/skidding/flatris) clone. [[play]](https://unsoundscapes.itch.io/flatris)
 - Elm 0.18
+  - [stil4m/elm-tetris](https://github.com/stil4m/elm-tetris) - Tetris game.
+  - [vishalgautamm/tetris-elm](https://github.com/vishalgautamm/tetris-elm) - Classic Tetris game.
   - [hoelzro/elm-tetris](https://github.com/hoelzro/elm-tetris) - A quick 'n' dirty implementation of Tetris.
   - [marcospri/elmtris](https://github.com/marcospri/elmtris) - Basic implementation of tetris. [[play]](https://marcospri.github.io/elmtris)
 - Elm 0.12
@@ -29,8 +41,11 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ### Breakout
 - Elm 0.18
+  - [granmoe/elm-brick-breaker](https://github.com/granmoe/elm-brick-breaker) - A stripped down brick breaker game. [[play]](https://granmoe.github.io/elm-brick-breaker)
   - [Dobiasd/Breakout](https://github.com/Dobiasd/Breakout) - A clone of the classical game for your browser. [[play]](http://daiw.de/games/breakout)
   - [hoelzro/elm-breakout](https://github.com/hoelzro/elm-breakout) - An implementation of Breakout.
+- Elm 0.17
+  - [griffinmichl/elm-brickbreaker](https://github.com/griffinmichl/elm-brickbreaker) - Breakout Clone.
 - Elm 0.12
   - [kbaba1001/elm-breakout](https://github.com/kbaba1001/elm-breakout)
 
@@ -59,11 +74,26 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [Evan's Mario Example](https://github.com/elm-lang/debug.elm-lang.org/blob/master/examples/Mario.elm) [[resources]](https://github.com/elm-lang/debug.elm-lang.org/tree/master/resources/imgs/mario) - Original example for mario in elm.
 
 ### Tic Tac Toe
+- Elm 0.19
+  - [Ultimate Tic-tac-toe](https://github.com/jjst/ultimate-tictactoe) - Tic Tac Toe Clone. An implementation of [ultimate tic-tac-toe](https://mathwithbaddrawings.com/2013/06/16/ultimate-tic-tac-toe/) in Elm.
 - Elm 0.18
-  - [ZeusTheTrueGod/elm-tictactoe](https://github.com/ZeusTheTrueGod/elm-tictactoe) - Tic Tac Toe Clone.
+  - [AllanNozomu/TicTacToe](https://github.com/AllanNozomu/TicTacToe) - Tic Tac Toe Clone.
+  - [franckverrot/tictactoe-elm](https://github.com/franckverrot/tictactoe-elm) - Tic Tac Toe game. [[play]](http://franck.verrot.fr/tictactoe-elm)
+  - [vishaltelangre/elm-tic-tac-toe](https://github.com/vishaltelangre/elm-tic-tac-toe) - Tic Tac Toe game. [[play]](https://tic-tac-toe.vishaltelangre.com)
+  - [ZeusTheTrueGod/elm-tictactoe](https://github.com/ZeusTheTrueGod/elm-tictactoe) - Tic Tac Toe Clone. [[play]](https://tictactoe.szeremi.org)
+- Elm 0.17
+  - [davefancher/ElmTicTacToe](https://github.com/davefancher/ElmTicTacToe) - A simple tic tac toe game.
+  - [jah2488/elm-ttt](https://github.com/jah2488/elm-ttt) - Tic Tac Toe Clone. [[play]](http://justinherrick.com/elm-ttt)
+  - [pel-daniel/elm-tictactoe](https://github.com/pel-daniel/elm-tictactoe) - Tic Tac Toe Clone. [[play]](https://pel-daniel.github.io/elm-tictactoe)
+  - [davydog187/elm-tic-tac-toe](https://github.com/davydog187/elm-tic-tac-toe) - Tic Tac Toe Clone.
+  - [amcsi/elm-tic-tac-toe](https://github.com/amcsi/elm-tic-tac-toe) - Tic Tac Toe Clone.
+- Elm 0.16
+  - [localshred/tic-tac-toe](https://github.com/localshred/tic-tac-toe) - Tic Tac Toe Clone.
 - [Chapter 12 Tic Tac Toe](https://github.com/grzegorzbalcerek/elm-by-example/blob/master/Chapter12TicTacToe.elm)  - Part of the elm-by-example book. Outdated (from 2015).
 
 ### Space Invaders
+- Elm 0.19
+  - [gege251/space_invaders](https://github.com/gege251/space_invaders) - Space Invaders game in Elm.
 - Elm 0.18
   - [Genetic Space Invaders game](https://github.com/j1nma/genetic-space-invaders) - A functional game written in Elm about classic space invaders game evolved with a genetic algorithm. [[play]](https://j1nma.github.io/genetic-space-invaders/)
 - Elm 0.16
@@ -73,16 +103,22 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ### Memory
 - Elm 0.18
+  - [alpacaaa/elm-memory-game](https://github.com/alpacaaa/elm-memory-game) - Memory game. [[doc]](https://alpacaaa.net/blog/post/elm-memory-game-from-scratch)
+  - [DaZzz/melmory-game](https://github.com/DaZzz/melmory-game) - Memory game.
+  - [Magic Match](https://github.com/FACN3/B12-subconsciousness) - Memory game. [[play]](https://ecstatic-fermi-1e0b0c.netlify.com/)
   - [Pairs.one](https://github.com/mxgrn/pairs.one) - A neat multiplayer online memory/concentration game. [[play]](https://pairs.one)
 - Elm 0.16
+  - [simonewebdesign/elm-memory-game](https://github.com/simonewebdesign/elm-memory-game) - Memory Game.
   - [simonewebdesign/elm-simon](https://github.com/simonewebdesign/elm-simon) - Memory Game.
 - Elm 0.15
+  - [Nazanin1369/elm-memoryGame](https://github.com/Nazanin1369/elm-memoryGame) - Memmory Game. Memory game using Elm. [[play]](http://nazanin1369.github.io/elm-memoryGame/)
   - [Cape Match](https://github.com/krisajenkins/cardmatch) - A little web game written in Elm (with some Haskell). [[play]](http://krisajenkins.github.io/cardmatch)
 
 ### Asteroid
 - Elm 0.17
   - [Elmsteroids](https://github.com/yupferris/elmsteroids) - A non-trivial Asteroids clone. [[play]](http://yupferris.github.io/elmsteroids)
 - Elm 0.16
+  - [AppSynergy/asteroids](https://github.com/AppSynergy/asteroids) - The classic asteroids game.
   - [Destroid](https://github.com/BlackBrane/destroid) - A space shooter based on the classic Asteroids.
 
 ### Pac Man
@@ -92,6 +128,8 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ### Minesweeper
 - Elm 0.18
+  - [CarstenKoenig/ElmSweeper](https://github.com/CarstenKoenig/ElmSweeper) - minesweeper game. [[play]](https://carstenkoenig.github.io/ElmSweeper)
+  - [lydell/elm-minesweeper](https://github.com/lydell/elm-minesweeper) - The classic game MineSweeper. [[play]](https://lydell.github.io/elm-minesweeper)
   - [roSievers/elm-sweeper](https://github.com/roSievers/elm-sweeper) - Elm Sweeper aims to reimplement the puzzle mechanics of Hexcells as a web application. [[play]](https://rosievers.github.io/elm-sweeper)
   - [brandly/elm-minesweeper](https://github.com/brandly/elm-minesweeper) - Classic Minesweeper. [[play]](https://brandly.github.io/elm-minesweeper/)
 - Elm 0.16
@@ -100,16 +138,38 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 ## Roguelike
 - Elm 0.19
   - [Dig Dig Boom](https://github.com/Orasund/pixelengine/tree/master/docs/DigDigBoom) - Roguelike with breakable walls. [[play]](https://orasund.itch.io/dig-dig-boom)
+- Elm 0.18
+  - [mordrax/cotwelm](https://github.com/mordrax/cotwelm) - Remake of Castle of the Winds in Elm. [[play]](http://game.castleofthewinds.com)
 - Elm 0.13
   - [deadfoxygrandpa/Roguelike](https://github.com/deadfoxygrandpa/Roguelike) - A roguelike.
 - [sindikat/roguelike](https://github.com/sindikat/roguelike) - Roguelike draft for testing Elm's Graphics.Collage performance.
 
 ## Classic Card & Board Game
+- Elm 0.19
+  - [kburton/elm-yahtzee](https://github.com/kburton/elm-yahtzee) - An implementation of the dice game Yahtzee written in elm. [[play]](https://elm-yahtzee.kappasoft.net)
+  - [RobStallion/chess-elm](https://github.com/RobStallion/chess-elm) - Trying to create a chess game in elm.
 - Elm 0.18
+  - [Depths](https://github.com/seagreen/depths) - Casual, single-player strategy game.
+  - [topher6345/blackjack-elm](https://github.com/topher6345/blackjack-elm) Blackjack Card Game. [[play]](https://simple-blackjack-in-elm.herokuapp.com)
+  - [arielger/elm-bingo](https://github.com/arielger/elm-bingo) - Bingo Game. [[play]](https://arielger.github.io/elm-bingo)
+  - [seandavidross/elm-haggis](https://github.com/seandavidross/elm-haggis) - A climbing card game.
+  - [Lattyware/massivedecks](https://github.com/Lattyware/massivedecks) - A Cards Against Humanity clone. [[play]](https://massivedecks.herokuapp.com)
+  - [alpacaaa/elm-mastermind](https://github.com/alpacaaa/elm-mastermind) - Mastermind game written in Elm. [[doc]](https://alpacaaa.net/blog/post/elm-mastermind-game)
+  - [Doubleheader](https://github.com/ndreynolds/doubleheader) - A multiplayer web version of the popular German card game "Doppelkopf".
+  - [Ring of Worlds](https://github.com/RoganMurley/Ring-of-Worlds) - Ring of Worlds: Multiplayer card game written in Haskell and Elm. [[play]](https://www.ringofworlds.com)
   - [girishso/indian-chess](https://github.com/girishso/indian-chess) - 18th Century chess like game developed. [[play]](http://indianchess.info)
   - [jinjor/elm-reversi](https://github.com/jinjor/elm-reversi) - Reversi Clone. [[play]](https://jinjor.github.io/elm-reversi)
-  - [cbenz/elm-bridge-game](https://github.com/cbenz/elm-bridge-game) - Card Game. Experimentations in Elm around Bridge card game using French standard. [[play]](https://cbenz.github.io/elm-bridge-game)
+  - [cbenz/elm-bridge-game](https://github.com/cbenz/elm-bridge-game) - Experimentations in Elm around Bridge card game using French standard. [[play]](https://cbenz.github.io/elm-bridge-game)
+- Elm 0.17
+  - [vanwagonet/elm-chess](https://github.com/vanwagonet/elm-chess) - Chess Game.
+  - [CarstenKoenig/ElmOthello](https://github.com/CarstenKoenig/ElmOthello) - [Reversi](https://en.wikipedia.org/wiki/Reversi) Clone. [[play]](https://carstenkoenig.github.io/ElmOthello)
+  - [inderps/reversi-game-in-elm](https://github.com/inderps/reversi-game-in-elm) - Reversi Game.
+  - [Diamondback Railroad](https://github.com/oc-elixir-elm/diamondback-railroad) - Demonstrates a game engine for a visually-pleasing 2-D game. [[play]](https://oc-elixir-elm.github.io)
+  - [bigardone/phoenix-elm-battleship](https://github.com/bigardone/phoenix-elm-battleship) - battleship clone built with Elixir, Phoenix, and Elm. [[play]](https://phoenix-elm-battleship.herokuapp.com)
+- Elm 0.16
+  - [infeo/elm-ninemensmorris](https://github.com/infeo/elm-ninemensmorris) - Nine men's morris Clone.
 - Elm 0.15
+  - [Kalevala](https://github.com/AlexNisnevich/kalevala) - A tile-laying game for two players inspired by the board game [Völuspá](https://www.whitegoblingames.com/game/126/Vlusp) by Scott Caputo. [[play]](http://alex.nisnevich.com/kalevala)
   - [Checkerboard Grid Tutorial](https://github.com/TheSeamau5/elm-checkerboardgrid-tutorial) - Tutorial on Container Components in Elm.
 - Elm 0.13
   - [grzegorzbalcerek/chess-elm](https://github.com/grzegorzbalcerek/chess-elm) - The game of Chess written in Elm.
@@ -121,12 +181,35 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ## Puzzle Games
 - Elm 0.19
+  - [darrensiegel/elm-chess](https://github.com/darrensiegel/elm-chess) - Human vs computer chess game.
+  - [lieberkind/sokoban](https://github.com/lieberkind/sokoban) - An implementation of the Sokoban game from Windows 3.x. [[play]](http://elm-sokoban.lieberkind.io)
+  - [brian-watkins/mindmaster](https://github.com/brian-watkins/mindmaster) - Code Breaking Game in Elm.
+  - [Seeds Game](https://github.com/andrewMacmurray/seeds-game) - A connect the dots game with seeds. [[play]](https://www.seedsgame.com/)
   - [battermann/elm-samegame](https://github.com/battermann/elm-samegame) - SameGame clone. [[play]](https://samegame.surge.sh)
 - Elm 0.18
+  - [dam5s/mastermind](https://github.com/dam5s/mastermind) - Mastermind Clone.
+  - [maorleger/mastermind](https://github.com/maorleger/mastermind) - Interactive Mastermind solver algorithm. [[play]](http://haskellmind.herokuapp.com)
+  - [girishso/elm-lights-out](https://github.com/girishso/elm-lights-out) - Light out clone. [[play]](https://girishso.github.io/elm-lights-out)
+  - [Juzley/elm-net](https://github.com/Juzley/elm-net) - Puzzle Game. This is an implementation of the Net puzzle game. [[play]](https://juzley.github.io/elm-net)
+  - [Drug Wars](https://github.com/thoughtbot/silk-road) - arbitrage game. [[play]](https://thoughtbot.github.io/silk-road/index.html)
+  - [campezzi/elm-fifteen](https://github.com/campezzi/elm-fifteen) - [15 Puzzle](https://www.wikiwand.com/en/15_puzzle) Clone. - [[play]](https://s3.amazonaws.com/campezzi/elm/fifteen.html)
+  - [ufocoder/sokoban](https://github.com/ufocoder/sokoban) - Sokoban game.[[play]](https://ufocoder.github.io/sokoban/dist/index.html)
+  - [ipavelpetrov/elm-floodit](https://github.com/ipavelpetrov/elm-floodit) - Flood It Game. [[play]](https://ipavelpetrov.github.io/elm-floodit)
+  - [G4BB3R/SokobanElm](https://github.com/G4BB3R/SokobanElm) - Remake of the classical game Sokoban in Elm.
+  - [zindel/game2048elm](https://github.com/zindel/game2048elm) - 2048 Clone.
   - [w0rm/elm-cubik](https://github.com/w0rm/elm-cubik) - This is an implementation of the Rubik's cube puzzle in the Elm language using WebGL. [[doc]](https://discourse.elm-lang.org/t/open-sourcing-the-rubiks-cube-game/746) [[play]](https://unsoundscapes.itch.io/cubik)
   - [jeanettehead/lady-boggle](https://github.com/jeanettehead/lady-boggle) - Boggle Clone. [[play]](http://iamjea.net/elm-boggle/game.html)
   - [Sokoban Player](https://github.com/krzysu/elm-sokoban-player) - Sokoban Player provides best experience to play any sokoban level you want! [[play]](https://sokoban-player.netlify.com)
   - [w0rm/elm-nim](https://github.com/w0rm/elm-nim) - A live-coded implementation of the [Nim](https://en.wikipedia.org/wiki/Nim) game in Elm as done at Berlin Frontend Meetup. [[doc]](https://unsoundscapes.com/slides/2016-06-07-introduction-to-elm/)
+- Elm 0.17
+  - [marcosh/elm-hanoi](https://github.com/marcosh/elm-hanoi) - Hanoi tower Clone.
+  - [ElmLive/lights-out](https://github.com/ElmLive/lights-out) - Light's Out Clone. [[doc]](https://www.youtube.com/watch?v=R6vuO547DC8)
+- Elm 0.16
+  - [erich-9/elm-sudoku](https://github.com/erich-9/elm-sudoku) -  Sudoku. [[play]](https://erich-9.github.io/elm-sudoku)
+  - [Paint The Town Red](https://github.com/mbylstra/paint-the-town-red) - Coloring game. [[play]](https://mbylstra.github.io/paint-the-town-red)
+- Elm 0.15
+  - [adzeitor/tis-100](https://github.com/adzeitor/tis-100) - tis-100 sandbox clone. [[play]](http://adzeitor.github.io/tis-100/)
+  - [gdeb/elm-sokoban](https://github.com/gdeb/elm-sokoban) - Sokoban Clone.
 - Elm 0.12
   - [maxsnew/Scramble](https://github.com/maxsnew/Scramble) - Word Scramble Game. [[play]](http://maxsnew.github.io/Scramble)
 
@@ -143,10 +226,41 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 
 ## Miscellaneous
 - Elm 0.19
+  - [danneu/elm-mmo](https://github.com/danneu/elm-mmo) - MMO RPG Game. [MUD](https://en.wikipedia.org/wiki/MUD)-like multiplayer game over websockets.
+  - [mpizenberg/elm-videoball](https://github.com/mpizenberg/elm-videoball) - Videoball clone. Minimalist elm implementation of the game videoball. [[play]](https://mpizenberg.github.io/elm-videoball)
+  - [anicholson/elm-hangman](https://github.com/anicholson/elm-hangman) - A hangman game.
+  - [Vim Adventures in Elm](https://github.com/mi-lee/vim-adventures-in-elm) - Dungeon Crawler. Vim Adventures game in Elm. [[play]](https://mi-lee.github.io/vim-adventures-in-elm/)
+  - [NuAshworld](https://github.com/Janiczek/nu-ashworld) - MMO RPG Game. A game in the vein of the (not playable anymore) Fallout-themed PBBG ["Ashworld"](https://web.archive.org/web/20090312000154/http://ashworld.webd.pl:80/index.php?strona=7). [[play]](https://janiczek.github.io/nu-ashworld/)
+  - [Bike-Wars](https://github.com/ohanhi/bike-wars) - Tron clone. Bike Wars is a two-player local multiplayer game where each player controls a Light Bike (like the ones in Tron) and tries to survive the longest.
   - [Mogee](https://github.com/w0rm/elm-mogee) - Platformer game. A WebGL platformer that fits into 64x64px screen. [[doc]](https://www.youtube.com/watch?v=NRXTMaXO15I) [[play]](https://unsoundscapes.itch.io/mogee)
   - [sonnym/scorched](https://github.com/sonnym/scorched) - Turn-based artillery game. A clone of Scorched Earth.
   - [JordyMoos/elm-pixel-boulder-game](https://github.com/JordyMoos/elm-pixel-boulder-game) - Boulder Dash Clone. A bit "out-of-hand" experiment to write a game in a pure functional language. [[play]](https://jordymoos.github.io/elm-pixel-boulder-game)
 - Elm 0.18
+  - [listrophy/space_elm](https://github.com/listrophy/space_elm) - Spaceship Game.
+  - [Fedreg/elmkc-simon](https://github.com/Fedreg/elmkc-simon) - Simon Says Clone. [[play]](https://github.com/Fedreg/elmkc-simon) [[play]](https://fedreg.github.io/elmkc-simon)
+  - [Wordy](https://github.com/adamdicarlo/elm-wordy) - Spelling Game. A clone of an iOS game called [Worder](https://itunes.apple.com/us/app/worder/id295069415?mt=8).
+  - [Obscura](https://github.com/saoirse-zee/obscura) - Simulation. You are a ghost in a dark universe governed by math and peopled by dullards. [[play]](http://obscura.surge.sh)
+  - [Village](https://github.com/danneu/village) - incremental game. [[play]](https://www.danneu.com/village)
+  - [lucashm/elmstroyer](https://github.com/lucashm/elmstroyer) - Spaceship Game. 
+  - [sd0s/elm-gallows](https://github.com/sd0s/elm-gallows) - Hangman Game. Elm UI for Hangman game.
+  - [naymspace/elm-bowling-game-kata](https://github.com/naymspace/elm-bowling-game-kata) - This is an adaption of [Uncle Bob's Bowling Game Kata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata).
+  - [Retrorace](https://github.com/nwjlyons/retrorace) - Racing Game. A multiplayer game where the aim is to be the first to reach the top of the screen. [[play]](http://retrorace.neillyons.io)
+  - [cjen07/gobblet-gobblers](https://github.com/cjen07/gobblet-gobblers) - Gobblet Gobblers Clone. [[play]](https://immense-fjord-94074.herokuapp.com/games/new)
+  - [The Adventures of Jack O'Lantern](https://github.com/jessicayzt/cpsc311_proj) - Platform game.
+  - [Constellations](https://github.com/jamesgary/constellations) - Planarity-inspired Game. [[play]](http://constellationsgame.com)
+  - [damien-theuveny/whack-a-fraudster](https://github.com/damien-theuveny/whack-a-fraudster) - Whack a Mole Clone.
+  - [xyc0562/editor-maze](https://github.com/xyc0562/editor-maze) - Maze Game.
+  - [crazymykl/elm-drench](https://github.com/crazymykl/elm-drench) -  Drench Clone. [[play]](https://crazymykl.github.io/elm-drench)
+  - [xpilot.io](https://github.com/mpdairy/xpilot.io) - Spaceship Game. a simple xpilot-like game. [[play]](http://xpilot.io)
+  - [billstclair/elm-jsmaze](https://github.com/billstclair/elm-jsmaze) -  Maze Game. A simple networked 2.5D maze game.  [[play]](https://jsmaze.com/) 
+  - [Boxuuume](https://github.com/rinn7e/boxuuume) - Platformer Game. A school project. [[play]](https://rinn7e.github.io/boxuuume)
+  - [Janiczek/dwarves](https://github.com/Janiczek/dwarves) - Minimal Dwarf Fortress-like behaviour in Elm. [[play]](https://janiczek.github.io/dwarves/index.html)
+  - [alpacaaa/elm-star-dodge](https://github.com/alpacaaa/elm-star-dodge) - Dodge Game. A simple star dodge game clone.
+  - [puemos/elm-hangman](https://github.com/puemos/elm-hangman) - Hangman Clone. The game of Hangman. [[play]](http://puemos.github.io/elm-hangman)
+  - [jamonholmgren/rocket-elm](https://github.com/jamonholmgren/rocket-elm) - Spaceship Game. A small game where you pilot a rocket ship around.
+  - [stephenbalaban/Gravity](https://github.com/stephenbalaban/Gravity) - Physic Simulation. An orbital simulation game written in Elm. [[play]](http://www.stephenbalaban.com/wp-content/uploads/2014/11/Gravity.html)
+  - [Hexliterate](https://github.com/ssimono/hexliterate) - Guessing Game. Fun game about guessing hex color code. [[play]](https://hex.sa-web.fr)
+  - [joelchelliah/elm-rex](https://github.com/joelchelliah/elm-rex) - Chrome's offline T-rex game written in Elm. [[play]](https://joelchelliah.github.io/elm-rex)
   - [WeAreWizards/elm-rocket-lander](https://github.com/WeAreWizards/elm-rocket-lander) - Rocket lander Game. A simple rocket lander game written in Elm
     - dead https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html
     - dead https://blog.wearewizards.io/experience-report-rocket-lander-in-elm
@@ -164,6 +278,15 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [brandly/elm-slime-volleyball](https://github.com/brandly/elm-slime-volleyball) - Gravity based game. try to beat the blue slime at volleyball. [[play]](https://brandly.github.io/elm-slime-volleyball/)
   - [Down the River](https://github.com/JoelQ/down-the-river) - Frogger Clone. Roman mythology themed game with procedural generation. [[play]](https://joelq.itch.io/down-the-river)
 - Elm 0.17
+  - [alexspurling/simonsays](https://github.com/alexspurling/simonsays) - Simon Says Clone. [[play]](http://alexspurling.github.io/simonsays)
+  - [Bee](https://github.com/trotha01/bee) - Top Down Game. [[play]](http://trotha01.github.io/bee)
+  - [Hexagons](https://github.com/janne/elm-hexagons) - Top Down Game.
+  - [ryannhg/seven-seas-elm](https://github.com/ryannhg/seven-seas-elm) - Sailing Game.
+  - [gentoid/sea-battle-elm](https://github.com/gentoid/sea-battle-elm) - Battleship Clone. "Sea Battle".
+  - [LetterSmash](https://github.com/blake-education/lettersmash) - Multiplayer Game. A multiplayer LetterPress game in Elixir, Phoenix and Elm. [[play]](https://lettersmash.herokuapp.com)
+  - [iojichervo/Generic-Elm-Platform-Game](https://github.com/iojichervo/Generic-Elm-Platform-Game) - Platformer Game. [[play]](https://iojichervo.github.io/Generic-Elm-Platform-Game)
+  - [Elm Practice 11](https://github.com/Chadtech/elm-prac-b) - Space Ship Game. the user must collect resources orbiting a planet and overcome the difficulty of maintaining good orbits! [[play]](http://www.chadtech.us/elm-prac-b)
+  - [Jan](https://github.com/brianstorti/jan) - Rock Paper Scissors Clone. A rock paper scissors game written in Elixir and Elm. [[play]](https://jkp.herokuapp.com)
   - [Melted Synapse](https://github.com/danneu/melted-synapse) - Fighting Game. A turn-based game written in Elm that explores Frozen Synapse's game mechanics [[play]](https://www.danneu.com/melted-synapse)
   - [danneu/elm-space-arena](https://github.com/danneu/elm-space-arena) - Space Shooter. A sloppy 2D spaceship shooter. [[play]](https://www.danneu.com/elm-space-arena)
   - https://github.com/krisajenkins/transcodegame - Point&Click Adventure. A point & click adventure written. [[play]](http://krisajenkins.github.io/transcodegame)
@@ -171,11 +294,21 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [cabaret/elm-supercrypt](https://github.com/cabaret/elm-supercrypt) - Decryption Game. Elm implementation of [SuperCrypt](http://www.kevindecock.be/apps/supercrypt).
   - [krisajenkins/wireworld](https://github.com/krisajenkins/wireworld) - Cellular automata. The WireWorld Cellular Automata.
 - Elm 0.16
+  - [kurtharriger/elm-battleship](https://github.com/kurtharriger/elm-battleship) - Battleship Game.
+  - [Grodan](https://github.com/yemi/grodan) - Frog Game.
+  - [rainbowbismuth/elm-turn-based-battle](https://github.com/rainbowbismuth/elm-turn-based-battle) - A turn based browser game written in Elm.
+  - [run-time/elm-ui-rocks](https://github.com/run-time/elm-ui-rocks) - Rock Paper Scissors Game. Elm-UI Rock, Paper, Scissors game. [[doc]](https://www.youtube.com/watch?v=fhMLEOr8C4U)
+  - [Starsystem](https://github.com/joakimk/starsystem) - spaceship game.
+  - [robinpokorny/elm-hangman](https://github.com/robinpokorny/elm-hangman) - Hangman clone. [[play]](http://robinpokorny.github.io/elm-hangman)
   - [Infinite Monkey Incremental](https://github.com/danneu/infinite-monkey-incremental) - Incremental Game. An incremental game inspired by the Infinite Monkey Theorem [[play]](https://www.danneu.com/infinite-monkey-incremental)
   - [jvoigtlaender/labyrinth-elm](https://github.com/jvoigtlaender/labyrinth-elm) - Arcade Game. A Pac-Man clone.[[play]](http://www.janis-voigtlaender.eu/elm-labyrinth)
   - [fbonetti/clicker-game](https://github.com/fbonetti/clicker-game) - Incremental Game. Cookie clicker clone.
   - [Elm Plane](https://github.com/odedw/elm-plane) - Autoscroller. A flappy bird clone written in elm. [[play]](http://www.odedwelgreen.com/elm-plane)
 - Elm 0.15
+  - [JoelQ/elm-platformer](https://github.com/JoelQ/elm-platformer) - Platformer Game. [[play]](https://joelq.github.io/elm-platformer)
+  - [robertjlooby/elm-bowling-game-kata](https://github.com/robertjlooby/elm-bowling-game-kata) - The [bowling game kata](http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata).
+  - [Salem](https://github.com/HaskellMN/salem) - Sailing Game. [[play]](https://kyle.marek-spartz.org/salem)
+  - [camspiers/elm-redchaser](https://github.com/camspiers/elm-redchaser) - Chasing Game. [[play]](http://camspiers.github.io/elm-redchaser)
   - [celestia](https://github.com/johnpmayer/celestia) - Spaceship Game. Celestia is a two-dimensional cartoon space game. [[play]](http://johnpmayer.github.io/celestia)
   - [avh4/wire-game](https://github.com/avh4/wire-game) - Network topology game.
   - [basti1302/elm-turing-machine-game](https://github.com/basti1302/elm-turing-machine-game) - Turing machine game.
@@ -184,6 +317,8 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
 - Elm 0.14
   - [Vessel](https://github.com/slawrence/vessel) - Autoscroller. A "tunnel" game. [[play]](http://slawrence.github.io/vessel)
   - [bamboo/take-the-blue-pills](https://github.com/bamboo/take-the-blue-pills) - Item Collecting Game. Take the blue pills Elm tutorial.
+- Elm 0.12
+  - [GoranM/bluepill](https://github.com/GoranM/bluepill) - A small avoider game, written in Elm.
 - [mgold/Sequence-Maze](https://github.com/mgold/Sequence-Maze) - Educational Game. A game for small children. Outdated (from 2014).
 - [Lopi/HackMan](https://github.com/Lopi/HackMan) - Hacking Game. A game to teach users about security and penetration testing. Outdated (from 2015).
 - [sonnym/petrov](https://github.com/sonnym/petrov) - Red Button Game. Don't press the button. [[play]](http://ludumdare.com/compo/ludum-dare-28/?action=preview&uid=28886)

--- a/README.md
+++ b/README.md
@@ -260,7 +260,6 @@ There is also separate repository for gamedev: [Elm Game Development](https://gi
   - [puemos/elm-hangman](https://github.com/puemos/elm-hangman) - Hangman Clone. The game of Hangman. [[play]](http://puemos.github.io/elm-hangman)
   - [jamonholmgren/rocket-elm](https://github.com/jamonholmgren/rocket-elm) - Spaceship Game. A small game where you pilot a rocket ship around.
   - [stephenbalaban/Gravity](https://github.com/stephenbalaban/Gravity) - Physic Simulation. An orbital simulation game written in Elm. [[play]](http://www.stephenbalaban.com/wp-content/uploads/2014/11/Gravity.html)
-  - [Hexliterate](https://github.com/ssimono/hexliterate) - Guessing Game. Fun game about guessing hex color code. [[play]](https://hex.sa-web.fr)
   - [joelchelliah/elm-rex](https://github.com/joelchelliah/elm-rex) - Chrome's offline T-rex game written in Elm. [[play]](https://joelchelliah.github.io/elm-rex)
   - [WeAreWizards/elm-rocket-lander](https://github.com/WeAreWizards/elm-rocket-lander) - Rocket lander Game. A simple rocket lander game written in Elm
     - dead https://blog.wearewizards.io/rocket-lander-in-elm-extra/ship.html


### PR DESCRIPTION
This is the complete list of all current games on Github that at that time had 3 or more stars.
I excluded all Game of Life clones. (125 in total)

There are a few new categories i would like to add: Chess, Mastermind, Sokoban, Light out, Hangman, Maze, Battleship ; Spaceship Games, Platformer Games, Incremental Games, Autoscroller Games.

Im thinking, maybe we should split off all clones into a seperate file?